### PR TITLE
[global] - Add init option

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -76,10 +76,9 @@ func (c *API) Run(validated *processing.Validate) {
 	log.Info().Msg("API server exited successfully")
 }
 
-// runPrerequisitesAndStartProcessing permit to run all functions
+// RunPrerequisitesOnly permit to run all functions
 // related to Kafka, elasticsearch and cockroach feeds
-// and then start processing all kafka messages
-func (c *API) runPrerequisitesAndStartProcessing(validated *processing.Validate) {
+func (c *API) RunPrerequisitesOnly(validated *processing.Validate) {
 	os.Setenv("SYNKER_CONFIG_DIR", c.ConfigDir)
 	defer os.Unsetenv("SYNKER_CONFIG_DIR")
 
@@ -98,6 +97,17 @@ func (c *API) runPrerequisitesAndStartProcessing(validated *processing.Validate)
 		log.Fatal().Err(err).Msg("Fail to manage changefeed")
 		return
 	}
+}
 
+// runPrerequisitesAndStartProcessing permit to run all functions
+// related to Kafka, elasticsearch and cockroach feeds
+// and then start processing all kafka messages
+func (c *API) runPrerequisitesAndStartProcessing(validated *processing.Validate) {
+	os.Setenv("SYNKER_CONFIG_DIR", c.ConfigDir)
+	defer os.Unsetenv("SYNKER_CONFIG_DIR")
+
+	if c.Init {
+		c.RunPrerequisitesOnly(validated)
+	}
 	validated.Processing()
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,11 +11,11 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// API command options
-func API(c *cli.Context) (z *cli.Command) {
+// Init command options
+func Init(c *cli.Context) (z *cli.Command) {
 	return &cli.Command{
-		Name:  "api",
-		Usage: "Start api server",
+		Name:  "init",
+		Usage: "Perform prerequisites related to elasticsearch / kafka / cockroachdb",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "config-dir",
@@ -23,13 +23,6 @@ func API(c *cli.Context) (z *cli.Command) {
 				Usage:       "Config dir name holding files",
 				Required:    true,
 				Destination: &cmdValidate.ConfigDir,
-			},
-			&cli.BoolFlag{
-				Name:        "init",
-				Aliases:     []string{"i"},
-				Usage:       "Perform prerequisites related to elasticsearch / kafka / cockroachdb",
-				Required:    false,
-				Destination: &cmdValidate.Init,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -47,7 +40,7 @@ func API(c *cli.Context) (z *cli.Command) {
 			}
 
 			cmdValidate.Run()
-			cmdAPI.Run(&cmdValidate)
+			cmdAPI.RunPrerequisitesOnly(&cmdValidate)
 			return nil
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ var (
 	VersionDetails *cli.Command
 	CmdValidate    *cli.Command
 	CmdAPI         *cli.Command
+	CmdInit        *cli.Command
 )
 
 func init() {
@@ -25,6 +26,7 @@ func init() {
 	CmdValidate = cmd.Validate(&cli.Context{})
 	VersionDetails = cmd.VersionDetails(&cli.Context{})
 	CmdAPI = cmd.API(&cli.Context{})
+	CmdInit = cmd.Init(&cli.Context{})
 }
 
 func main() {
@@ -38,6 +40,7 @@ func main() {
 	app.Commands = []*cli.Command{
 		VersionDetails,
 		CmdValidate,
+		CmdInit,
 		CmdAPI,
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,35 @@ func TestMain(t *testing.T) {
 	time.Sleep(1 * time.Second)
 }
 
+func TestMain_init(t *testing.T) {
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt)
+
+	go func() {
+		<-sigc
+		os.Args = []string{
+			"synker",
+			"init",
+			"-c",
+			"processing/examples/schemas",
+		}
+		main()
+		signal.Stop(sigc)
+	}()
+	time.Sleep(1 * time.Minute)
+
+	err = proc.Signal(os.Interrupt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Second)
+}
+
 func TestMain_api(t *testing.T) {
 	proc, err := os.FindProcess(os.Getpid())
 	if err != nil {
@@ -55,6 +84,36 @@ func TestMain_api(t *testing.T) {
 			"api",
 			"-c",
 			"processing/examples/schemas",
+		}
+		main()
+		signal.Stop(sigc)
+	}()
+	time.Sleep(1 * time.Minute)
+
+	err = proc.Signal(os.Interrupt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(1 * time.Second)
+}
+
+func TestMain_api_init(t *testing.T) {
+	proc, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc, os.Interrupt)
+
+	go func() {
+		<-sigc
+		os.Args = []string{
+			"synker",
+			"api",
+			"-c",
+			"processing/examples/schemas",
+			"-i",
 		}
 		main()
 		signal.Stop(sigc)

--- a/models/models.go
+++ b/models/models.go
@@ -13,6 +13,8 @@ type Configuration struct {
 	ValidatedFiles []ValidatedFiles
 	// List of validated schemas
 	ValidatedSchemas Schemas
+	// Init will only perform prerequisites related to elasticsearch / kafka / cockroachdb
+	Init bool
 }
 
 // List of validated files with SQL queries


### PR DESCRIPTION
Related to https://github.com/Lord-Y/synker/issues/8

The result is:
```bash
go run main.go --help
NAME:
   synker - A new cli with an api to sync data between databases and elasticsearch

USAGE:
   synker [global options] command [command options]

VERSION:
   0.0.1-dev

DESCRIPTION:
   synker permit you to validate config and sync data from databases to elasticsearch

COMMANDS:
   version-details  print version details of the cli
   validate         options related to configuration file
   init             Perform prerequisites related to elasticsearch / kafka / cockroachdb
   api              Start api server
   help, h          Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```

```bash
go run main.go init --help
NAME:
   synker init - Perform prerequisites related to elasticsearch / kafka / cockroachdb

USAGE:
   synker init [command options]

OPTIONS:
   --config-dir value, -c value  Config dir name holding files
   --help, -h                    show help
```

```bash
go run main.go api --help
NAME:
   synker api - Start api server

USAGE:
   synker api [command options]

OPTIONS:
   --config-dir value, -c value  Config dir name holding files
   --init, -i                    Perform prerequisites related to elasticsearch / kafka / cockroachdb (default: false)
   --help, -h                    show help
```